### PR TITLE
optional : allow creating a configurable rabbitmq.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The RabbitMQ version to install for Ubuntu 20.04.
 
     rabbitmq_bullseye_version: "3.15.8"
 
+The RabbitMQ version to install for Ubuntu 22.04.
+
+    rabbitmq_bullseye_version: "3.8.33"
+
 The RabbitMQ version to install for Debian Bullseye.
 
     rabbitmq_el8_version: "3.8.8"
@@ -40,9 +44,11 @@ The RabbitMQ version to install for Centos8.
 
     rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
     rabbitmq_focal_deb: "rabbitmq-server_{{ rabbitmq_focal_version }}-1_all.deb"
+    rabbitmq_jammy_deb: "rabbitmq-server_{{ rabbitmq_jammy_version }}-1_all.deb"
     rabbitmq_bullseye_deb: "rabbitmq-server_{{ rabbitmq_bullseye_version }}-1_all.deb"
     rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
     rabbitmq_focal_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bionic/{{ rabbitmq_focal_deb }}/download"
+    rabbitmq_jammy_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/jammy/{{ rabbitmq_jammy_deb }}/download"
     rabbitmq_bullseye_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bullseye/{{ rabbitmq_bullseye_deb }}/download"
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Installs RabbitMQ on Linux.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
     rabbitmq_daemon: rabbitmq-server
     rabbitmq_state: started
@@ -56,7 +56,9 @@ The RabbitMQ version to install for Centos8.
 
 ## Dependencies
 
-None.
+### community.rabbitmq
+
+    ansible-galaxy collection install community.rabbitmq
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ rabbitmq_enabled: yes
 rabbitmq_version: "{{ '3.7.18' if ansible_distribution_release == 'buster' else '3.6.16' }}"
 rabbitmq_bullseye_version: "3.8.15"
 rabbitmq_focal_version: "3.8.8"
+rabbitmq_jammy_version: "3.8.33"
 rabbitmq_el8_version: "3.8.8"
 
 rabbitmq_rpm: "rabbitmq-server-{{ rabbitmq_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
@@ -16,7 +17,9 @@ rabbitmq_gpg_key: "https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey"
 
 rabbitmq_deb: "rabbitmq-server_{{ rabbitmq_version }}-1_all.deb"
 rabbitmq_focal_deb: "rabbitmq-server_{{ rabbitmq_focal_version }}-1_all.deb"
+rabbitmq_jammy_deb: "rabbitmq-server_{{ rabbitmq_jammy_version }}-1_all.deb"
 rabbitmq_bullseye_deb: "rabbitmq-server_{{ rabbitmq_bullseye_version }}-1_all.deb"
 rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
 rabbitmq_focal_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bionic/{{ rabbitmq_focal_deb }}/download"
+rabbitmq_jammy_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/jammy/{{ rabbitmq_jammy_deb }}/download"
 rabbitmq_bullseye_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bullseye/{{ rabbitmq_bullseye_deb }}/download"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,11 @@ rabbitmq_users: []
 
 # users to remove
 rabbitmq_users_remove: []
+
+rabbitmq_cfg_file: /etc/rabbitmq/rabbitmq.conf
+
+# if some cfg settings are enabled, the {{ rabbitmq_cfg_file }} file will be created from template
+rabbitmq_cfg_settings: {}
+# example
+# rabbitmq_cfg_settings:
+#   "log.file.level": warning

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,12 @@ rabbitmq_bullseye_deb: "rabbitmq-server_{{ rabbitmq_bullseye_version }}-1_all.de
 rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
 rabbitmq_focal_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bionic/{{ rabbitmq_focal_deb }}/download"
 rabbitmq_bullseye_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bullseye/{{ rabbitmq_bullseye_deb }}/download"
+
+
+rabbitmq_cfg_file: /etc/rabbitmq/rabbitmq.conf
+
+# if some cfg settings are enabled, the {{ rabbitmq_cfg_file }} file will be created from template
+rabbitmq_cfg_settings: {}
+# example
+# rabbitmq_cfg_settings:
+#   "log.file.level": warning

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: yes
 
-rabbitmq_version: "{{ '3.7.18' if ansible_distribution_release == 'buster' else  '3.6.16' }}"
+rabbitmq_version: "{{ '3.7.18' if ansible_distribution_release == 'buster' else '3.6.16' }}"
 rabbitmq_bullseye_version: "3.8.15"
 rabbitmq_focal_version: "3.8.8"
 rabbitmq_el8_version: "3.8.8"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,14 @@ rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ 
 rabbitmq_focal_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bionic/{{ rabbitmq_focal_deb }}/download"
 rabbitmq_jammy_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/jammy/{{ rabbitmq_jammy_deb }}/download"
 rabbitmq_bullseye_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bullseye/{{ rabbitmq_bullseye_deb }}/download"
+
+# vhosts
+# https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_vhost_module.html
+rabbitmq_vhosts: []
+
+# define users
+# https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_user_module.html
+rabbitmq_users: []
+
+# users to remove
+rabbitmq_users_remove: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
-- name: restart rabbitmq
-  service: "name={{ rabbitmq_daemon }} state=restarted"
+- name: Restart rabbitmq
+  ansible.builtin.service: "name={{ rabbitmq_daemon }} state=restarted"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,8 @@ galaxy_info:
       - "bullseye"
       - "jessie"
       - "stretch"
+  dependencies:
+    - community.rabbitmq
   galaxy_tags:
     - application
     - system

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,22 +6,22 @@ galaxy_info:
   description: "RabbitMQ installation for Linux"
   company: "Ascensio System SIA"
   license: "GNU AGPL v3.0"
-  min_ansible_version: 2.3
+  min_ansible_version: "2.3"
   platforms:
     - name: EL
       versions:
-      - 7
-      - 8
+      - "7"
+      - "8"
     - name: Ubuntu
       versions:
-      - xenial
-      - bionic
-      - focal
+      - "xenial"
+      - "bionic"
+      - "focal"
     - name: Debian
       versions:
-      - bullseye
-      - jessie
-      - stretch
+      - "bullseye"
+      - "jessie"
+      - "stretch"
   galaxy_tags:
     - application
     - system

--- a/tasks/Bullseye.yml
+++ b/tasks/Bullseye.yml
@@ -1,10 +1,11 @@
 ---
 - name: Download RabbitMQ package.
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_bullseye_deb_url }}"
     dest: "/tmp/{{ rabbitmq_bullseye_deb }}"
+    mode: '0644'
 
 - name: Ensure RabbitMQ is installed.
-  apt:
+  ansible.builtin.apt:
     deb: "/tmp/{{ rabbitmq_bullseye_deb }}"
     state: present

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,10 +1,11 @@
 ---
 - name: Download RabbitMQ package.
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_deb_url }}"
     dest: "/tmp/{{ rabbitmq_deb }}"
+    mode: '0644'
 
 - name: Ensure RabbitMQ is installed.
-  apt:
+  ansible.builtin.apt:
     deb: "/tmp/{{ rabbitmq_deb }}"
     state: present

--- a/tasks/Focal.yml
+++ b/tasks/Focal.yml
@@ -1,10 +1,11 @@
 ---
 - name: Download RabbitMQ package.
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_focal_deb_url }}"
     dest: "/tmp/{{ rabbitmq_focal_deb }}"
+    mode: '0644'
 
 - name: Ensure RabbitMQ is installed.
-  apt:
+  ansible.builtin.apt:
     deb: "/tmp/{{ rabbitmq_focal_deb }}"
     state: present

--- a/tasks/Jammy.yml
+++ b/tasks/Jammy.yml
@@ -1,0 +1,11 @@
+---
+- name: Download RabbitMQ package.
+  ansible.builtin.get_url:
+    url: "{{ rabbitmq_jammy_deb_url }}"
+    dest: "/tmp/{{ rabbitmq_jammy_deb }}"
+    mode: '0644'
+
+- name: Ensure RabbitMQ is installed.
+  ansible.builtin.apt:
+    deb: "/tmp/{{ rabbitmq_jammy_deb }}"
+    state: present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,15 +1,16 @@
 ---
 - name: Add packagecloud GPG key.
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: "{{ rabbitmq_gpg_key }}"
     state: present
 
 - name: Download RabbitMQ package.
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_rpm_url }}"
     dest: "/tmp/{{ rabbitmq_rpm }}"
+    mode: '0644'
 
 - name: Ensure RabbitMQ is installed.
-  yum:
+  ansible.builtin.yum:
     name: "/tmp/{{ rabbitmq_rpm }}"
     state: "present"

--- a/tasks/RedHat8.yml
+++ b/tasks/RedHat8.yml
@@ -1,16 +1,17 @@
 ---
 - name: Add packagecloud GPG key.
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: "{{ rabbitmq_gpg_key }}"
     state: present
 
 - name: Download RabbitMQ package.
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_el8_rpm_url }}"
     dest: "/tmp/{{ rabbitmq_el8_rpm }}"
+    mode: '0644'
 
 - name: Ensure RabbitMQ is installed.
-  dnf:
+  ansible.builtin.dnf:
     name: "/tmp/{{ rabbitmq_el8_rpm }}"
     state: "present"
     disable_gpg_check: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,3 +39,25 @@
     name: "{{ rabbitmq_daemon }}"
     state: "{{ rabbitmq_state }}"
     enabled: "{{ rabbitmq_enabled }}"
+
+- name: Ensure rabbitmq vhosts
+  community.rabbitmq.rabbitmq_vhost:
+    name: "{{ item }}"
+  with_items: "{{ rabbitmq_vhosts }}"
+
+- name: Ensure the users present
+  community.rabbitmq.rabbitmq_user:
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    configure_priv: "{{ item.configure_priv | default('.*') }}"
+    read_priv: "{{ item.read_priv | default('.*') }}"
+    write_priv: "{{ item.write_priv | default('.*') }}"
+    vhost: "{{ item.vhost | default('/') }}"
+    tags: "{{ item.tags | default('') }}"
+  with_items: "{{ rabbitmq_users }}"
+
+- name: Ensure the users removed
+  community.rabbitmq.rabbitmq_user:
+    user: "{{ item }}"
+    state: absent
+  with_items: "{{ rabbitmq_users_remove }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,16 @@
   ansible.builtin.include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
+- name: rabbitmqi.conf
+  template:
+    src: rabbitmq.conf.j2
+    dest: "{{ rabbitmq_cfg_file }}"
+    mode: 0644
+    owner: root
+    group: root
+  when: rabbitmq_cfg_settings
+  notify: restart rabbitmq
+
 - name: Ensure rabbitmq is started and enabled (if configured).
   ansible.builtin.service:
     name: "{{ rabbitmq_daemon }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: rabbitmq.conf
+- name: Generate rabbitmq.conf
   template:
     src: rabbitmq.conf.j2
     dest: "{{ rabbitmq_cfg_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Generate rabbitmq.conf
-  template:
+  ansible.builtin.template:
     src: rabbitmq.conf.j2
     dest: "{{ rabbitmq_cfg_file }}"
     mode: 0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   ansible.builtin.include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: rabbitmqi.conf
+- name: rabbitmq.conf
   template:
     src: rabbitmq.conf.j2
     dest: "{{ rabbitmq_cfg_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Install epel
+  ansible.builtin.package:
+    name: epel-release
+    state: present
+  when: ansible_os_family == "RedHat"
+
 - name: Install erlang
   ansible.builtin.package:
     name: erlang

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
-- name: rabbitmqi.conf
+- name: rabbitmq.conf
   template:
     src: rabbitmq.conf.j2
     dest: "{{ rabbitmq_cfg_file }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,31 @@
 ---
 - name: Install erlang
-  package:
+  ansible.builtin.package:
     name: erlang
     state: present
 
 - name: Include Debian tasks
-  include_tasks: "Debian.yml"
+  ansible.builtin.include_tasks: "Debian.yml"
   when: (ansible_os_family == "Debian" and ansible_distribution_release != "focal" and ansible_distribution_release != "bullseye" )
 
 - name: Include Ubuntu2004 tasks
-  include_tasks: "Focal.yml"
+  ansible.builtin.include_tasks: "Focal.yml"
   when: ansible_distribution_release == "focal"
 
 - name: Include Debian Bullseye tasks
-  include_tasks: "Bullseye.yml"
+  ansible.builtin.include_tasks: "Bullseye.yml"
   when: ansible_distribution_release == "bullseye"
 
 - name: Include Centos7 install tasks
-  include_tasks: "{{ ansible_os_family }}.yml"
+  ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version != "8"
 
 - name: Include Centos8 install tasks
-  include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
+  ansible.builtin.include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
 - name: Ensure rabbitmq is started and enabled (if configured).
-  service:
+  ansible.builtin.service:
     name: "{{ rabbitmq_daemon }}"
     state: "{{ rabbitmq_state }}"
     enabled: "{{ rabbitmq_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: facts
+  setup:
+  when: ansible_os_family is not defined
+
 - name: Install erlang
   package:
     name: erlang
@@ -23,6 +27,16 @@
 - name: Include Centos8 install tasks
   include_tasks: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+- name: rabbitmqi.conf
+  template:
+    src: rabbitmq.conf.j2
+    dest: "{{ rabbitmq_cfg_file }}"
+    mode: 0644
+    owner: root
+    group: root
+  when: rabbitmq_cfg_settings
+  notify: restart rabbitmq
 
 - name: Ensure rabbitmq is started and enabled (if configured).
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     owner: root
     group: root
   when: rabbitmq_cfg_settings
-  notify: restart rabbitmq
+  notify: Restart rabbitmq
 
 - name: Ensure rabbitmq is started and enabled (if configured).
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,15 @@
 
 - name: Include Debian tasks
   ansible.builtin.include_tasks: "Debian.yml"
-  when: (ansible_os_family == "Debian" and ansible_distribution_release != "focal" and ansible_distribution_release != "bullseye" )
+  when: (ansible_os_family == "Debian" and ansible_distribution_release != "focal" and ansible_distribution_release != "bullseye" and ansible_distribution_release != "jammy")
 
 - name: Include Ubuntu2004 tasks
   ansible.builtin.include_tasks: "Focal.yml"
   when: ansible_distribution_release == "focal"
+
+- name: Include Ubuntu2204 tasks
+  ansible.builtin.include_tasks: "Jammy.yml"
+  when: ansible_distribution_release == "jammy"
 
 - name: Include Debian Bullseye tasks
   ansible.builtin.include_tasks: "Bullseye.yml"

--- a/templates/rabbitmq.conf.j2
+++ b/templates/rabbitmq.conf.j2
@@ -1,0 +1,5 @@
+#jinja2: lstrip_blocks: True
+# {{ ansible_managed }}
+{% for k, v in rabbitmq_cfg_settings.items() | list %}
+{{ k }} = {{ v }}
+{% endfor %}


### PR DESCRIPTION
allow creating a configurable rabbitmq.conf
vars:
```yaml
rabbitmq_cfg_file: /etc/rabbitmq/rabbitmq.conf
rabbitmq_cfg_settings: {}
# example
# rabbitmq_cfg_settings:
#   "log.file.level": warning
```