### PR TITLE
Add handle user and vhost configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Installs RabbitMQ on Linux.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are listed below, along with default values (see [defaults/main.yml](defaults/main.yml)):
 
     rabbitmq_daemon: rabbitmq-server
     rabbitmq_state: started

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ The RabbitMQ version to install for Centos8.
 
 ## Dependencies
 
-None.
+### community.rabbitmq
+
+    ansible-galaxy collection install community.rabbitmq
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,3 +20,14 @@ rabbitmq_bullseye_deb: "rabbitmq-server_{{ rabbitmq_bullseye_version }}-1_all.de
 rabbitmq_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/{{ ansible_distribution_release }}/{{ rabbitmq_deb }}/download"
 rabbitmq_focal_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bionic/{{ rabbitmq_focal_deb }}/download"
 rabbitmq_bullseye_deb_url: "https://packagecloud.io/rabbitmq/rabbitmq-server/packages/{{ ansible_distribution | lower }}/bullseye/{{ rabbitmq_bullseye_deb }}/download"
+
+# vhosts
+# https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_vhost_module.html
+rabbitmq_vhosts: []
+
+# define users
+# https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_user_module.html
+rabbitmq_users: []
+
+# users to remove
+rabbitmq_users_remove: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,8 @@ galaxy_info:
       - bullseye
       - jessie
       - stretch
+  dependencies:
+    - community.rabbitmq
   galaxy_tags:
     - application
     - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,3 +29,25 @@
     name: "{{ rabbitmq_daemon }}"
     state: "{{ rabbitmq_state }}"
     enabled: "{{ rabbitmq_enabled }}"
+
+- name: Ensure rabbitmq vhosts
+  rabbitmq_vhost:
+    name: "{{ item }}"
+  with_items: "{{ rabbitmq_vhosts }}"
+
+- name: Ensure the users is present
+  rabbitmq_user:
+    user: "{{ item.user }}"
+    password: "{{ item.password }}"
+    configure_priv: "{{ item.configure_priv | default('.*') }}"
+    read_priv: "{{ item.read_priv | default('.*') }}"
+    write_priv: "{{ item.write_priv | default('.*') }}"
+    vhost: "{{ item.vhost | default('/') }}"
+    tags: "{{ item.tags | default('') }}"
+  with_items: "{{ rabbitmq_users }}"
+
+- name: Ensure the users is removed
+  rabbitmq_user:
+    user: "{{ item }}"
+    state: absent
+  with_items: "{{ rabbitmq_users_remove }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,12 +31,12 @@
     enabled: "{{ rabbitmq_enabled }}"
 
 - name: Ensure rabbitmq vhosts
-  rabbitmq_vhost:
+  community.rabbitmq.rabbitmq_vhost:
     name: "{{ item }}"
   with_items: "{{ rabbitmq_vhosts }}"
 
 - name: Ensure the users present
-  rabbitmq_user:
+  community.rabbitmq.rabbitmq_user:
     user: "{{ item.user }}"
     password: "{{ item.password }}"
     configure_priv: "{{ item.configure_priv | default('.*') }}"
@@ -47,7 +47,7 @@
   with_items: "{{ rabbitmq_users }}"
 
 - name: Ensure the users removed
-  rabbitmq_user:
+  community.rabbitmq.rabbitmq_user:
     user: "{{ item }}"
     state: absent
   with_items: "{{ rabbitmq_users_remove }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
     name: "{{ item }}"
   with_items: "{{ rabbitmq_vhosts }}"
 
-- name: Ensure the users is present
+- name: Ensure the users present
   rabbitmq_user:
     user: "{{ item.user }}"
     password: "{{ item.password }}"
@@ -46,7 +46,7 @@
     tags: "{{ item.tags | default('') }}"
   with_items: "{{ rabbitmq_users }}"
 
-- name: Ensure the users is removed
+- name: Ensure the users removed
   rabbitmq_user:
     user: "{{ item }}"
     state: absent


### PR DESCRIPTION
Despite the fact that some VARs regarding rabbitmq users and vhosts are listed in https://github.com/ONLYOFFICE/ansible-role-documentserver, this role is missing the required tasks to add the required users and vhosts.
This PR adds the missing tasks.