### PR TITLE
avoid error message while including var files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,11 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Include OS specific variables
-  ansible.builtin.include_vars: "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
+  ansible.builtin.include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+      - "{{ ansible_os_family }}{{ ansible_distribution_major_version }}.yml"
+      - "{{ ansible_os_family }}.yml"
   ignore_errors: true
 
 - name: Include OS specific tasks


### PR DESCRIPTION
Avoid irritating error messages like
```
fatal: [oo.zero-sys.net]: FAILED! => {"ansible_facts": {}, "ansible_included_var_files": [], "changed": false, "message": "Could not find or access 'Debian12.yml'\nSearched in:...
```
(even if they are ignored, human eye sees red ...)

And from my point of view, fix overwriting more specific vars with general vars (for example, if I want to set `erlang_version: 25.3.2.9` in `Debian12.yml` and the general setting in `Debian.yml` is different, including `Debian.yml` a second time after `Debian12.yml` will set the version to the generic one defined in `Debian.yml`