### PR TITLE
updated rabbitmq and erlang versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,8 @@ rabbitmq_daemon: rabbitmq-server
 rabbitmq_state: started
 rabbitmq_enabled: true
 
-erlang_version: 25.3.2.7
-rabbitmq_version: 3.11.24
+erlang_version: 27.2-1
+rabbitmq_version: 4.0.5-1
 
 # vhosts
 # https://docs.ansible.com/ansible/latest/collections/community/rabbitmq/rabbitmq_vhost_module.html


### PR DESCRIPTION
old versions are not available anymore (at least for debian 12)
```yaml
erlang_version: 27.2-1
rabbitmq_version: 4.0.5-1
```
